### PR TITLE
Fix tag parsing for HentaiCafe

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/HentaiCafe.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/HentaiCafe.kt
@@ -52,12 +52,12 @@ class HentaiCafe(delegate: HttpSource) : DelegatedHttpSource(delegate),
     override fun parseIntoMetadata(metadata: HentaiCafeSearchMetadata, input: Document) {
         with(metadata) {
             url = input.location()
-            title = input.select(".entry-title").text()
+            title = input.select("h3").text()
             val contentElement = input.select(".entry-content").first()
             thumbnailUrl = contentElement.child(0).child(0).attr("src")
 
             fun filterableTagsOfType(type: String) = contentElement.select("a")
-                    .filter { "$baseUrl/$type/" in it.attr("href") }
+                    .filter { "$baseUrl/hc.fyi/$type/" in it.attr("href") }
                     .map { it.text() }
 
             tags.clear()


### PR DESCRIPTION
Closes #107 

HentaiCafe urls seem to have a hc.fyi segment in the url now, unsure why
Tag parsing is updated to reflect this

Fixed the title selector

I have tested my code
![image](https://user-images.githubusercontent.com/12771982/66369289-820b3300-e9e7-11e9-9a62-c65c7109d76d.png)
